### PR TITLE
Rename example -> examples to fix typing errors

### DIFF
--- a/agent-specification.yaml
+++ b/agent-specification.yaml
@@ -149,30 +149,30 @@ components:
         id:
           type: string
           description: Unique identifier for the agent.
-          example: urn:agent:finance:trading_agent:1
+          examples: [urn:agent:finance:trading_agent:1]
         name:
           type: string
           description: Human-readable name of the agent.
-          example: My Trading Agent
+          examples: [My Trading Agent]
         fullyQualifiedName:
           type: string
           description: Fully qualified name of the agent.
-          example: My Trading Agent
+          examples: [My Trading Agent]
         description:
           type: string
           description: Describes the agent’s purpose and role.
         domain:
           type: string
           description: The domain in which the agent operates.
-          example: finance
+          examples: [finance]
         version:
           type: string
           description: The version of the agent.
-          example: 1.0.0
+          examples: [1.0.0]
         environment:
           type: string
           description: Execution environment (e.g., development, production).
-          example: production
+          examples: [production]
         agentOwner:
           type: string
           description: The primary owner of the agent.
@@ -182,15 +182,15 @@ components:
         email:
           type: string
           description: Contact email for the agent.
-          example: mailto:support@corp.com
+          examples: [mailto:support@corp.com]
         status:
           type: string
           description: Deployment status of the agent.
-          example: ACTIVE
+          examples: [ACTIVE]
         kind:
           type: string
           description: Agent type to support different agentic system architectures
-          example: Supervisor
+          examples: [Supervisor]
           enum:
             - Supervisor
             - Single Agent
@@ -199,7 +199,8 @@ components:
         agentGoal:
           type: string
           description: optimize returns and risk
-          example: Try to keep the balance between a yield return of 10% and a portfolio volatility no more than 3%
+          examples:
+            - Try to keep the balance between a yield return of 10% and a portfolio volatility no more than 3%
         targetUser:
           type: string
           description: The final user of the agent
@@ -209,7 +210,7 @@ components:
         valueGeneration:
           type: string
           description: In which way this Agent generates value for the organization
-          example: "Derisking"
+          examples: ["Derisking"]
           enum:
             - DecisionMaking
             - Derisking
@@ -219,7 +220,7 @@ components:
         interactionMode:
           type: string
           description: Mode of execution (e.g., autonomous, human in the loop).
-          example: "Autonoumous"
+          examples: ["Autonoumous"]
           enum:
             - RequestResponse
             - MultiTurnConversation
@@ -228,7 +229,7 @@ components:
         runMode:
           type: string
           description: How the agent execution is triggered
-          example: "Scheduled"
+          examples: ["Scheduled"]
           enum:
             - Reactive
             - Scheduled
@@ -237,7 +238,7 @@ components:
         agencyLevel:
           type: string
           description: How big is the agency for this agent
-          example: "Rule Constrained"
+          examples: ["Rule Constrained"]
           enum:
             - StaticWorkflow
             - ModelDrivenWorkflow
@@ -249,7 +250,7 @@ components:
         learningCapability:
           type: string
           description: How the agent will learn on the way
-          example: "Reinforcement Learning"
+          examples: ["Reinforcement Learning"]
           enum:
             - None
             - Reinforcement Learning
@@ -262,17 +263,17 @@ components:
             apiUrl:
               type: string
               description: The primary API URL for interacting with the agent.
-              example: "https://api.tradingagent.com/v1"
+              examples: ["https://api.tradingagent.com/v1"]
             authenticationMethod:
               type: string
               description: Type of authentication required.
-              example: "OAuth2"
+              examples: ["OAuth2"]
             supportedMethods:
               type: array
               description: List of HTTP methods supported.
               items:
                 type: string
-              example: ["GET", "POST", "PUT", "DELETE"]
+              examples: [["GET", "POST", "PUT", "DELETE"]]
         dependencies:
           type: array
           description: List of other agents this agent relies on.
@@ -298,15 +299,15 @@ components:
             healthCheck:
               type: string
               description: Automated monitoring endpoint.
-              example: "https://api.tradingagent.com/v1/health"
+              examples: ["https://api.tradingagent.com/v1/health"]
             decisionLogs:
               type: string
               description: Endpoint to retrieve decision logs.
-              example: "https://api.tradingagent.com/v1/logs"
+              examples: ["https://api.tradingagent.com/v1/logs"]
             anomalyDetection:
               type: string
               description: API endpoint for anomaly detection.
-              example: "https://api.tradingagent.com/v1/anomalies"
+              examples: ["https://api.tradingagent.com/v1/anomalies"]
         knowledgeBases:
           type: array
           description: Where this agent reads data from.
@@ -325,26 +326,26 @@ components:
                   - Streaming
                   - Historical
                 description: Type of data source.
-                example: "Structured"
+                examples: ["Structured"]
               description:
                 type: string
               endpoint:
                 type: string
                 description: API or database connection string.
-                example: "https://datawarehouse.company.com/api"
+                examples: ["https://datawarehouse.company.com/api"]
         securityInfo:
           type: object
           description: Security and compliance details.
           properties:
             visibility:
               type: string
-              example: Private
+              examples: [Private]
             confidentiality:
               type: string
-              example: High
+              examples: [High]
             gdprSensitive:
               type: boolean
-              example: true
+              examples: [true]
         specific:
           type: object
           description: Any domain-specific metadata related to the agent.
@@ -360,11 +361,11 @@ components:
         id:
           type: string
           description: Unique identifier for the component.
-          example: urn:component:my_domain:tool:1
+          examples: [urn:component:my_domain:tool:1]
         name:
           type: string
           description: Human-readable name of the component.
-          example: Trade Execution Tool
+          examples: [Trade Execution Tool]
         kind:
           type: string
           description: Type of component (e.g., Tool, LLM, LocalMemory, Guardrail, Monitor, Orchestrator).
@@ -374,15 +375,15 @@ components:
             - LocalMemory
             - Guardrail
             - Orchestrator
-          example: Tool
+          examples: [Tool]
         version:
           type: string
           description: Version of the component.
-          example: 1.0.0
+          examples: [1.0.0]
         description:
           type: string
           description: Describes the component's purpose and role.
-          example: Executes trades via Interactive Brokers API.
+          examples: [Executes trades via Interactive Brokers API.]
         dependencies:
           type: array
           description: List of other components or data sources the component depends on.
@@ -398,7 +399,7 @@ components:
         endpoint:
           type: string
           description: MCP endpoint to interact with the component
-          example: https://api.tradingtool.com/v1/execute
+          examples: [https://api.tradingtool.com/v1/execute]
         specific:
           type: object
           description: Additional metadata specific to the component.
@@ -411,11 +412,11 @@ components:
             inputFormat:
               type: string
               description: Expected input format (e.g., JSON, XML, CSV).
-              example: JSON
+              examples: [JSON]
             outputFormat:
               type: string
               description: Expected output format.
-              example: JSON
+              examples: [JSON]
     LLM:
       allOf:
         - $ref: "#/components/schemas/AgentComponent"
@@ -424,15 +425,15 @@ components:
             modelName:
               type: string
               description: The name of the large language model used.
-              example: GPT-4
+              examples: [GPT-4]
             fineTuned:
               type: boolean
               description: Whether the model has been fine-tuned for a specific task.
-              example: true
+              examples: [true]
             apiProvider:
               type: string
               description: Provider of the model API.
-              example: OpenAI
+              examples: [OpenAI]
     LocalMemory:
       allOf:
         - $ref: "#/components/schemas/AgentComponent"
@@ -441,11 +442,11 @@ components:
             storageType:
               type: string
               description: Type of memory storage (e.g., Redis, SQLite, In-Memory Cache).
-              example: Redis
+              examples: [Redis]
             persistence:
               type: boolean
               description: Whether the memory persists across agent runs.
-              example: true
+              examples: [true]
     Guardrail:
       allOf:
         - $ref: "#/components/schemas/AgentComponent"
@@ -457,15 +458,15 @@ components:
                 - Hard
                 - Soft
               description: Defines whether the rule is strictly enforced or flexible.
-              example: Hard
+              examples: [Hard]
             condition:
               type: string
               description: Business condition enforced by the guardrail.
-              example: "Prevent trade execution if risk exceeds 5%"
+              examples: ["Prevent trade execution if risk exceeds 5%"]
             action:
               type: string
               description: Action taken when the guardrail is triggered (e.g., block, notify, log).
-              example: "Block trade"
+              examples: ["Block trade"]
     Orchestrator:
       allOf:
         - $ref: "#/components/schemas/AgentComponent"
@@ -474,10 +475,10 @@ components:
             workflowManagement:
               type: string
               description: Defines how the orchestrator manages workflows.
-              example: "State-based workflow engine"
+              examples: ["State-based workflow engine"]
             executionOrder:
               type: array
               description: Defines the sequence of components executed.
               items:
                 type: string
-              example: ["Tool", "Memory", "LLM"]
+              examples: [["Tool", "Memory", "LLM"]]

--- a/scripts/generate_model.sh
+++ b/scripts/generate_model.sh
@@ -2,4 +2,11 @@
 
 echo '- Generating the pydantic model'
 
-uv run datamodel-codegen --input agent-specification.yaml --input-file-type openapi --output model.py
+uv run datamodel-codegen \
+    --use-standard-collections \
+    --use-union-operator \
+    --use-annotated \
+    --input agent-specification.yaml \
+    --input-file-type openapi \
+    --output model.py \
+


### PR DESCRIPTION
The generated pydantic model has typing errors when the specs uses the `example` attribute instead of `examples`. This commit fixes it.