### PR TITLE
Added supportedInput and supportedOutput fields

### DIFF
--- a/agent-specification.yaml
+++ b/agent-specification.yaml
@@ -256,6 +256,22 @@ components:
             - Reinforcement Learning
             - Fine Tuning
 
+        supportedInput:
+          type: array
+          description: List of supported input formats or content types.
+          items:
+            type: string
+            enum: [text, images, video, files]
+          examples: [["text", "images"]]
+
+        supportedOutput:
+          type: array
+          description: List of supported output formats or content types.
+          items:
+            type: string
+            enum: [text, images, video, files]
+          examples: [["text", "files"]]
+
         endpoint:
           type: object
           description: Defines where external systems or users can communicate with the agent.

--- a/examples/health-care.yaml
+++ b/examples/health-care.yaml
@@ -16,6 +16,8 @@ runMode: "Reactive"
 agencyLevel: "ModelDrivenWorkflow"
 toolsUse: true
 learningCapability: "Fine Tuning"
+supportedInput: ["text"]
+supportedOutput: ["text"]
 
 endpoint:
   apiUrl: "https://api.healthcareai.org/diagnostics/v3"

--- a/spec.md
+++ b/spec.md
@@ -46,6 +46,8 @@ The agent descriptor follows an **OpenAPI 3.0-based** schema to enable easy docu
   - `ModelDrivenWorkflow`: the agent is implement as a workflow. The execution through the workflow is controlled by LLMs.
 - `toolsUse` *(string)* – Define if the system can use tools in order to execute its task. Values: true/false.
 - `learningCapability` *(string)* – Learning approach (None, Reinforcement Learning, Fine Tuning).
+- `supportedInput` *(array)* – Supported input types (e.g., text, images, video, files).
+- `supportedOutput` *(array)* – Supported output types (e.g., text, images, video, files)
 
 ### **Technical Configuration**
 - `physicalEndpoint` *(object)* – Defines where and how external systems interact with the agent.
@@ -92,6 +94,10 @@ executionMode: "Autonomous"
 runMode: "RealTime"
 agencyLevel: "Rule Constrained"
 learningCapability: "Reinforcement Learning"
+supportedInput:
+  - text
+supportedOutput:
+  - text
 
 physicalEndpoint:
   apiUrl: "https://api.tradingagent.com/v1"

--- a/spec.md
+++ b/spec.md
@@ -46,8 +46,8 @@ The agent descriptor follows an **OpenAPI 3.0-based** schema to enable easy docu
   - `ModelDrivenWorkflow`: the agent is implement as a workflow. The execution through the workflow is controlled by LLMs.
 - `toolsUse` *(string)* – Define if the system can use tools in order to execute its task. Values: true/false.
 - `learningCapability` *(string)* – Learning approach (None, Reinforcement Learning, Fine Tuning).
-- `supportedInput` *(array)* – Supported input types (e.g., text, images, video, files).
-- `supportedOutput` *(array)* – Supported output types (e.g., text, images, video, files)
+- `supportedInput` *(array)* – List of supported output formats or content types (e.g., text, images, video, files).
+- `supportedOutput` *(array)* – List of supported output formats or content types (e.g., text, images, video, files)
 
 ### **Technical Configuration**
 - `physicalEndpoint` *(object)* – Defines where and how external systems interact with the agent.
@@ -94,10 +94,8 @@ executionMode: "Autonomous"
 runMode: "RealTime"
 agencyLevel: "Rule Constrained"
 learningCapability: "Reinforcement Learning"
-supportedInput:
-  - text
-supportedOutput:
-  - text
+supportedInput: ["text"]
+supportedOutput: ["text"]
 
 physicalEndpoint:
   apiUrl: "https://api.tradingagent.com/v1"


### PR DESCRIPTION
📝 Summary

This pull request introduces two new optional fields to the AgentDescriptor schema:
	•	supportedInput: defines which input types the agent can handle.
	•	supportedOutput: defines which output types the agent can produce.

Both fields accept a checklist of the following values:
	•	text
	•	images
	•	video
	•	files

📌 Motivation

These additions aim to make agent capabilities more explicit and machine-readable, enabling better discoverability, filtering, and compatibility validation across agentic systems.

🔧 Changes
	•	Added supportedInput and supportedOutput as arrays of strings with fixed enums to components.schemas.AgentDescriptor.

✅ Example
```yaml
supportedInput: ["text", "images"]
supportedOutput: ["text", "files"]
```

📚 Documentation

The OpenAPI specification has been updated accordingly in the AgentDescriptor schema block.